### PR TITLE
add fallback option

### DIFF
--- a/resources/views/partials/select-options.blade.php
+++ b/resources/views/partials/select-options.blade.php
@@ -1,7 +1,7 @@
 @if($options)
     @foreach($options as $option)
-        <option value="{{($value?$option->$value:null)??$option->value ?? $option->id ?? $option->name?? 'option'. $loop->iteration }}">
-            {{ $option->label ?? (method_exists($option, 'label') ? $option->label() : null) ?? $option->name ?? $option->nom ?? $option->id ?? 'Option '. $loop->iteration }}
+        <option value="{{($value?$option->$value:null)??$option->value ?? $option->id ?? $option->name?? $option }}">
+            {{ $option->label ?? (method_exists($option, 'label') ? $option->label() : null) ?? $option->name ?? $option->nom ?? $option->id ?? $option }}
         </option>
     @endforeach
 @endif


### PR DESCRIPTION
This pull request includes a small change to the `resources/views/partials/select-options.blade.php` file. The change simplifies the `value` attribute assignment in the `<option>` tag by using the `$option` directly if no other value is found.

* Simplified the `value` attribute assignment in the `<option>` tag to use `$option` directly if other values are not available. (`resources/views/partials/select-options.blade.php`)